### PR TITLE
Support git-gutter+

### DIFF
--- a/nord-theme.el
+++ b/nord-theme.el
@@ -431,6 +431,11 @@
     `(git-gutter:added ((,class (:foreground ,nord14))))
     `(git-gutter:deleted ((,class (:foreground ,nord11))))
 
+    ;; > Git Gutter Plus
+    `(git-gutter+-modified ((,class (:foreground ,nord13))))
+    `(git-gutter+-added ((,class (:foreground ,nord14))))
+    `(git-gutter+-deleted ((,class (:foreground ,nord11))))
+
     ;; > Helm
     `(helm-bookmark-addressbook ((,class (:foreground ,nord7))))
     `(helm-bookmark-directory ((,class (:foreground ,nord9))))


### PR DESCRIPTION
This PR is to support [git-gutter+](https://github.com/nonsequitur/git-gutter-plus) which is included in Spacemacs and other starter kits.