### PR TITLE
helm-swoop support

### DIFF
--- a/nord-theme.el
+++ b/nord-theme.el
@@ -474,8 +474,10 @@
     `(helm-selection ((,class (:inherit highlight))))
     `(helm-selection-line ((,class (:background ,nord2))))
     `(helm-source-header ((,class (:height 1.44 :foreground ,nord8 :background ,nord2))))
+    `(helm-swoop-line-number-face ((,class (:foreground ,nord4 :background ,nord0))))
     `(helm-swoop-target-word-face ((,class (:foreground ,nord0 :background ,nord7))))
     `(helm-swoop-target-line-face ((,class (:background ,nord13 :foreground ,nord3))))
+    `(helm-swoop-target-line-block-face ((,class (:background ,nord13 :foreground ,nord3))))
     `(helm-separator ((,class (:background ,nord2))))
     `(helm-visible-mark ((,class (:background ,nord2))))
 

--- a/nord-theme.el
+++ b/nord-theme.el
@@ -474,6 +474,8 @@
     `(helm-selection ((,class (:inherit highlight))))
     `(helm-selection-line ((,class (:background ,nord2))))
     `(helm-source-header ((,class (:height 1.44 :foreground ,nord8 :background ,nord2))))
+    `(helm-swoop-target-word-face ((,class (:foreground ,nord0 :background ,nord7))))
+    `(helm-swoop-target-line-face ((,class (:background ,nord13 :foreground ,nord3))))
     `(helm-separator ((,class (:background ,nord2))))
     `(helm-visible-mark ((,class (:background ,nord2))))
 


### PR DESCRIPTION
From the default,

<img width="611" alt="screen shot 2017-04-23 at 6 51 32 pm" src="https://cloud.githubusercontent.com/assets/1378791/25311472/fcbfc27e-2855-11e7-84ee-b429a9ecb034.png">

to 

<img width="614" alt="screen shot 2017-04-23 at 6 49 27 pm" src="https://cloud.githubusercontent.com/assets/1378791/25311473/00e71bd6-2856-11e7-8d5b-d7b073cd6130.png">