### PR TITLE
mu4e: Highlight Maildir with unread emails

### DIFF
--- a/nord-theme.el
+++ b/nord-theme.el
@@ -522,7 +522,7 @@
     `(mu4e-header-key-face ((,class (:foreground ,nord8))))
     `(mu4e-highlight-face ((,class (:highlight))))
     `(mu4e-flagged-face ((,class (:foreground ,nord13))))
-    `(mu4e-unread-face ((,class (:foreground ,nord4 :weight bold))))
+    `(mu4e-unread-face ((,class (:foreground ,nord13 :weight bold))))
     `(mu4e-link-face ((,class (:underline t))))
 
     ;; > Powerline


### PR DESCRIPTION
Highlighting Maildirs that contain unread emails. Currently too subtle IMHO.

Changing from

<img width="150" alt="screen shot 2017-05-06 at 10 28 16 am" src="https://cloud.githubusercontent.com/assets/1378791/25766520/22528152-3247-11e7-8a78-ce3cfd7751af.png">

to

<img width="153" alt="screen shot 2017-05-06 at 10 28 43 am" src="https://cloud.githubusercontent.com/assets/1378791/25766521/239c194c-3247-11e7-8dfa-06bd7e85f9ae.png">