### PR TITLE
 Added syntax highlighting to eshell

### DIFF
--- a/nord-theme.el
+++ b/nord-theme.el
@@ -488,17 +488,17 @@
 
     ;; > Eshell
     `(eshell-prompt ((,class (:foreground ,nord9 :weight bold))))
-    `(eshell-ls-archive ((,class (:foreground ,nord11 :weight bold))))
+    `(eshell-ls-archive ((,class (:foreground ,nord14 :weight bold))))
     `(eshell-ls-backup ((,class (:inherit font-lock-comment-face))))
     `(eshell-ls-clutter ((,class (:inherit font-lock-comment-face))))
-    `(eshell-ls-directory ((,class (:foreground ,nord8 :weight bold))))
+    `(eshell-ls-directory ((,class (:foreground ,nord7 :weight bold))))
     `(eshell-ls-executable ((,class (:foreground ,nord11 :weight bold))))
-    `(eshell-ls-unreadable ((,class (:foreground ,nord15))))
+    `(eshell-ls-unreadable ((,class (:foreground ,nord6))))
     `(eshell-ls-missing ((,class (:inherit font-lock-warning-face))))
     `(eshell-ls-product ((,class (:inherit font-lock-doc-face))))
     `(eshell-ls-special ((,class (:foreground ,nord13 :weight bold))))
-    `(eshell-ls-symlink ((,class (:foreground ,nord7 :weight bold))))
-    `(eshell-ls-readonly ((,class (:foreground, nord14))))
+    `(eshell-ls-symlink ((,class (:foreground ,nord7))))
+    `(eshell-ls-readonly ((,class (:foreground, nord15))))
 
     ;; > Flycheck
     `(flycheck-error ((,class (:underline (:style wave :color ,nord11)))))

--- a/nord-theme.el
+++ b/nord-theme.el
@@ -486,6 +486,20 @@
     `(evil-ex-substitute-replacement ((,class (:foreground ,nord9))))
     `(evil-ex-substitute-matches ((,class (:inherit isearch))))
 
+    ;; > Eshell
+    `(eshell-prompt ((,class (:foreground ,nord9 :weight bold))))
+    `(eshell-ls-archive ((,class (:foreground ,nord11 :weight bold))))
+    `(eshell-ls-backup ((,class (:inherit font-lock-comment-face))))
+    `(eshell-ls-clutter ((,class (:inherit font-lock-comment-face))))
+    `(eshell-ls-directory ((,class (:foreground ,nord8 :weight bold))))
+    `(eshell-ls-executable ((,class (:foreground ,nord11 :weight bold))))
+    `(eshell-ls-unreadable ((,class (:foreground ,nord15))))
+    `(eshell-ls-missing ((,class (:inherit font-lock-warning-face))))
+    `(eshell-ls-product ((,class (:inherit font-lock-doc-face))))
+    `(eshell-ls-special ((,class (:foreground ,nord13 :weight bold))))
+    `(eshell-ls-symlink ((,class (:foreground ,nord7 :weight bold))))
+    `(eshell-ls-readonly ((,class (:foreground, nord14))))
+
     ;; > Flycheck
     `(flycheck-error ((,class (:underline (:style wave :color ,nord11)))))
     `(flycheck-fringe-error ((,class (:foreground ,nord11 :weight bold))))


### PR DESCRIPTION
Before this pull request, nord-emacs didn't have support for the eshell syntax. There were only a couple of faces missing, so I added them all in. I tried my best to match the style seen in dir-colors and the terminal.app, but eshell has a limited number of faces to style. 

Old Behavior:
<img width="500" alt="screen shot 2017-12-06 at 1 01 28 pm" src="https://user-images.githubusercontent.com/11581528/33677218-061f2282-da86-11e7-84e9-d73bf2f8db02.png">


New Behavior:
<img width="500" alt="screen shot 2017-12-06 at 12 52 55 pm" src="https://user-images.githubusercontent.com/11581528/33677225-0bea9b06-da86-11e7-8f35-229bf55907e4.png">
