### PR TITLE
Fix syntax error introduced in GH-81

### DIFF
--- a/nord-theme.el
+++ b/nord-theme.el
@@ -634,7 +634,7 @@
     `(org-level-5 ((,class (:inherit org-level-4))))
     `(org-level-6 ((,class (:inherit org-level-4))))
     `(org-level-7 ((,class (:inherit org-level-4))))
-    `(org-level-8 ((,class (:inherit org-level-4)))))
+    `(org-level-8 ((,class (:inherit org-level-4))))
     `(org-agenda-structure ((,class (:foreground ,nord9))))
     `(org-agenda-date ((,class (:foreground ,nord8 :underline nil))))
     `(org-agenda-done ((,class (:foreground ,nord14))))


### PR DESCRIPTION
The theme fails to load due to this syntax error, please fix. (also, why is the melpa package connected to the development branch? because of things like this, it makes more sense to connect it to the master branch) 