### PR TITLE
Migrate deprecated `show-paren-X-face` faces

### DIFF
--- a/nord-theme.el
+++ b/nord-theme.el
@@ -275,8 +275,17 @@
     `(region ((,class (:foreground ,nord-region-highlight-foreground :background ,nord-region-highlight-background))))
     `(scroll-bar ((,class (:background ,nord3))))
     `(secondary-selection ((,class (:background ,nord2))))
+
+    ;; `show-paren-match-face` and `show-paren-mismatch-face` are deprecated since Emacs version 22.1 and were
+    ;; removed in Emacs 25.
+    ;; https://github.com/arcticicestudio/nord-emacs/issues/75
+    ;; http://git.savannah.gnu.org/cgit/emacs.git/commit/?id=c430f7e23fc2c22f251ace4254e37dea1452dfc3
+    ;; https://github.com/emacs-mirror/emacs/commit/c430f7e23fc2c22f251ace4254e37dea1452dfc3
     `(show-paren-match-face ((,class (:foreground ,nord0 :background ,nord8))))
     `(show-paren-mismatch-face ((,class (:background ,nord11))))
+
+    `(show-paren-match ((,class (:foreground ,nord0 :background ,nord8))))
+    `(show-paren-mismatch ((,class (:background ,nord11))))
     `(success ((,class (:foreground ,nord14))))
     `(term ((,class (:foreground ,nord4 :background ,nord0))))
     `(term-color-black ((,class (:foreground ,nord1 :background ,nord1))))


### PR DESCRIPTION
Closes #75 

---

The `show-paren-match-face` and `show-paren-mismatch-face` face are [deprecated since Emacs version 22.1][c] and were [removed in Emacs 25][cm].
To provide compatibility to later Emacs version, the new `show-paren-match` and `show-paren-mismatch` faces have been added.

The deprecated faces will be removed later on, but for now its totally fine for both faces to co-exist to support Emacs versions <22.1 as well as >=22.1.

[c]: http://git.savannah.gnu.org/cgit/emacs.git/commit/?id=c430f7e23fc2c22f251ace4254e37dea1452dfc3
[cm]: https://github.com/emacs-mirror/emacs/commit/c430f7e23fc2c22f251ace4254e37dea1452dfc3