### PR TITLE
Add support for ivy-posframe

### DIFF
--- a/nord-theme.el
+++ b/nord-theme.el
@@ -705,7 +705,9 @@
     `(ivy-minibuffer-match-face-2 ((,class (:background ,nord7 :foreground ,nord0))))
     `(ivy-minibuffer-match-face-3 ((,class (:background ,nord8 :foreground ,nord0))))
     `(ivy-minibuffer-match-face-4 ((,class (:background ,nord9 :foreground ,nord0))))
-    `(ivy-remote ((,class (:foreground ,nord14))))))
+    `(ivy-remote ((,class (:foreground ,nord14))))
+    `(ivy-posframe ((,class (:background ,nord1))))
+    `(ivy-posframe-border ((,class (:background ,nord1))))))
 
 ;;;###autoload
 (when (and (boundp 'custom-theme-load-path) load-file-name)


### PR DESCRIPTION
This pull request adds themes for Ivy Posframe. 

By default, the inherited posframe theme has the same background color as buffers, and it is hard to distinguish where the posframe ends and the buffer begins. This commit sets the background for ivy-posframe and ivy-posframe-border to nord1.