### PR TITLE
Fully inherit mode-line in mode-line-buffer-id

### DIFF
--- a/nord-theme.el
+++ b/nord-theme.el
@@ -245,7 +245,7 @@
     `(mm-command-output ((,class (:foreground ,nord8))))
     `(mode-line ((,class (:foreground ,nord8 :background ,nord3))))
     `(mode-line-buffer-id ((,class (:foreground ,nord8 :weight bold))))
-    `(mode-line-highlight ((,class (:inherit highlight))))
+    `(mode-line-highlight ((,class (:foreground ,nord13 :weight bold))))
     `(mode-line-inactive ((,class (:foreground ,nord4 :background ,nord-uniform-mode-lines-background))))
     `(next-error ((,class (:inherit error))))
     `(nobreak-space ((,class (:foreground ,nord3))))

--- a/nord-theme.el
+++ b/nord-theme.el
@@ -244,7 +244,7 @@
     `(minibuffer-prompt ((,class (:foreground ,nord8 :weight bold))))
     `(mm-command-output ((,class (:foreground ,nord8))))
     `(mode-line ((,class (:foreground ,nord8 :background ,nord3))))
-    `(mode-line-buffer-id ((,class (:weight bold))))
+    `(mode-line-buffer-id ((,class (:inherit mode-line :weight bold))))
     `(mode-line-highlight ((,class (:inherit highlight))))
     `(mode-line-inactive ((,class (:foreground ,nord4 :background ,nord-uniform-mode-lines-background))))
     `(next-error ((,class (:inherit error))))
@@ -509,7 +509,7 @@
    `(diff-hl-change ((,class (:background ,nord13))))
    `(diff-hl-insert ((,class (:background ,nord14))))
    `(diff-hl-delete ((,class (:background ,nord11))))
-   
+
     ;; > Evil
     `(evil-ex-info ((,class (:foreground ,nord8))))
     `(evil-ex-substitute-replacement ((,class (:foreground ,nord9))))

--- a/nord-theme.el
+++ b/nord-theme.el
@@ -244,7 +244,7 @@
     `(minibuffer-prompt ((,class (:foreground ,nord8 :weight bold))))
     `(mm-command-output ((,class (:foreground ,nord8))))
     `(mode-line ((,class (:foreground ,nord8 :background ,nord3))))
-    `(mode-line-buffer-id ((,class (:inherit mode-line :weight bold))))
+    `(mode-line-buffer-id ((,class (:foreground ,nord8 :weight bold))))
     `(mode-line-highlight ((,class (:inherit highlight))))
     `(mode-line-inactive ((,class (:foreground ,nord4 :background ,nord-uniform-mode-lines-background))))
     `(next-error ((,class (:inherit error))))


### PR DESCRIPTION
I have two themes installed and switch among them using a mechanism similar to that described in 
https://stackoverflow.com/questions/23793288/cycle-custom-themes-w-emacs-24
When switching, you need, at least the foreground colour in addition to `:weight bold` to display the mode-line correctly.
