### PR TITLE
Add ERC support

### DIFF
--- a/nord-theme.el
+++ b/nord-theme.el
@@ -509,6 +509,22 @@
    `(diff-hl-change ((,class (:background ,nord13))))
    `(diff-hl-insert ((,class (:background ,nord14))))
    `(diff-hl-delete ((,class (:background ,nord11))))
+
+   ;; > ERC
+   `(erc-action-face ((,class (:foreground ,nord7))))
+   `(erc-current-nick-face ((,class (:foreground ,nord8 :weight unspecified))))
+   `(erc-dangerous-host-face ((,class (:foreground ,nord11))))
+   `(erc-direct-msg-face ((,class (:foreground ,nord11))))
+   `(erc-error-face ((,class (:foreground ,nord11))))
+   `(erc-fool-face ((,class (:foreground ,nord-comment))))
+   `(erc-input-face ((,class (:foreground ,nord8 :weight unspecified))))
+   `(erc-keyword-face ((,class (:foreground ,nord15 :weight bold))))
+   `(erc-my-nick-face ((,class (:foreground ,nord8 :weight bold))))
+   `(erc-nick-msg-face ((,class (:foreground ,nord11 :weight bold))))
+   `(erc-notice-face ((,class (:foreground ,nord-comment :weight unspecified))))
+   `(erc-pal-face ((,class (:foreground ,nord15 :weight bold))))
+   `(erc-prompt-face ((,class (:foreground ,nord0 :background ,nord8 :weight bold))))
+   `(erc-timestamp-face ((,class (:foreground ,nord10))))
    
     ;; > Evil
     `(evil-ex-info ((,class (:foreground ,nord8))))


### PR DESCRIPTION
ERC is the IRC client which is built-in to Emacs.

This should be a decently complete theme, personally I had only changed about 4 faces to get it to a usable state for myself, however before submitting I went above and beyond and set several more.

I did not, however, set any of the fg:erc-color-face[0-15] nor bg:erc-color-face[0-15], as I have never even seen those used anywhere (maybe on a terminal? but I am GUI user).  There were a few more oddball ones I did not bother with either, but I don't think they are important and I never saw them used anywhere, either.

I took a couple screen shots:

N.B.: I am using some custom ELisp to assign different colors to different nicks, that is not part of this commit.

![2023-01-23-000128_ERC_nord-emacs_WIP_screenshot](https://user-images.githubusercontent.com/25938297/213982564-9a4d084e-b9d0-4dcb-92bd-a2ad3ffb3cf7.png)

![2023-01-23-015848_ERC_nord-emacs_WIP_screenshot](https://user-images.githubusercontent.com/25938297/213982584-1e4e6ccf-a540-4f23-b6fc-5821c079fcbd.png)